### PR TITLE
Renew two weeks before expiry

### DIFF
--- a/src/getazurecert
+++ b/src/getazurecert
@@ -44,7 +44,7 @@ if test -f "$cert_file"; then
         now=$(date +"%s")
         echo "Now    : $now"
 
- 	let renewby="$endstamp - (3600 * 24)"
+ 	let renewby="$endstamp - (3600 * 336)"
 
 	if [ $now -gt $renewby ]; then
 		echo "Certificate needs to be downloaded"


### PR DESCRIPTION
Renew cert sooner to allow more time for detection of auto-renewal issues before expiry.